### PR TITLE
Tweaks to readme

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "VML"
 uuid = "c8ce9da6-5d36-5c03-b118-5a70151be7bc"
+version = "0.2.0"
 
 [deps]
 CpuId = "adafc99b-e345-5852-983c-f28acb93d879"
@@ -7,7 +8,8 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-julia = "≥ 0.7 1.0"
+julia = "0.7 1.0"
+CpuId = "0.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
I think the `@time` examples in the readme were testing compilation time. And I wanted to upgrade the warning about replacing matrix exp to be a bit stronger. 

And while I was doing things I fixed up Project.toml a bit. 